### PR TITLE
Handle/test CCX keys with trailing whitespace

### DIFF
--- a/ccx_keys/locator.py
+++ b/ccx_keys/locator.py
@@ -40,11 +40,11 @@ class CCXLocator(CourseLocator, CCXKey):
         BLOCK_TYPE_PREFIX=CourseLocator.BLOCK_TYPE_PREFIX,
         BLOCK_PREFIX=CourseLocator.BLOCK_PREFIX,
         CCX_PREFIX=CCX_PREFIX,
-        SEP=r'(\+(?=.)|$)',  # Separator: requires a non-trailing '+' or end of string
+        SEP=r'(\+(?=.)|\Z)',  # Separator: requires a non-trailing '+' or end of string
     )
 
     URL_RE = re.compile(
-        '^' + URL_RE_SOURCE + '$', re.IGNORECASE | re.VERBOSE | re.UNICODE
+        '^' + URL_RE_SOURCE + r'\Z', re.IGNORECASE | re.VERBOSE | re.UNICODE
     )
 
     def __init__(self, **kwargs):
@@ -128,7 +128,7 @@ class CCXBlockUsageLocator(BlockUsageLocator, UsageKey):
     CANONICAL_NAMESPACE = 'ccx-block-v1'
 
     URL_RE = re.compile(
-        '^' + CCXLocator.URL_RE_SOURCE + '$', re.IGNORECASE | re.VERBOSE | re.UNICODE
+        '^' + CCXLocator.URL_RE_SOURCE + r'\Z', re.IGNORECASE | re.VERBOSE | re.UNICODE
     )
 
     def replace(self, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='edx-ccx-keys',
-    version='0.2.0',
+    version='0.2.1',
     author='edX',
     author_email='oscm@edx.org',
     description='Opaque key support custom courses on edX',


### PR DESCRIPTION
Related to: https://openedx.atlassian.net/browse/ECOM-5345

Change regex for CCX keys/locators. Add tests for CCX keys with trailing whitespace.

