### PR TITLE
Update CCX Keys from Course -> LearningContext

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='edx-ccx-keys',
-    version='0.2.2',
+    version='1.0.0',
     author='edX',
     author_email='oscm@edx.org',
     description='Opaque key support custom courses on edX',
@@ -24,11 +24,11 @@ setup(
         'ccx_keys',
     ],
     install_requires=[
-        'edx-opaque-keys>=1.0.1,<2.0.0',
+        'edx-opaque-keys>=2.0.0,<3.0.0',
         'six>=1.10.0,<2.0.0'
     ],
     entry_points={
-        'course_key': [
+        'context_key': [
             'ccx-v1 = ccx_keys.locator:CCXLocator',
         ],
         'usage_key': [


### PR DESCRIPTION
This is a change to make this repo compatible with https://github.com/edx/opaque-keys/pull/108

The build is failing because the new version of `edx-opaque-keys` that it needs isn't published to PyPI yet.