### PR TITLE
[BD-6] Add tests in python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 language: python
 python:
-  - 2.7
   - 3.5
+  - 3.8
 install:
+  - pip install pip==20.0.2
   - make requirements
   - pip install coveralls
+envs:
+  - TOXENV=quality
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.8
+      env: TOXENV=py38
 script:
-  - make test
-  - make quality
+  - tox
 after_success:
   - coveralls
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ html_coverage:
 	coverage html && open htmlcov/index.html
 
 quality:
-	pycodestyle --config=.pep8 ccx_keys
-	pylint --rcfile=pylintrc ccx_keys
+	tox -e quality
 
 requirements: ## install development environment requirements
 	pip install -qr requirements/pip-tools.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-edx-opaque-keys==2.0.1    # via -r requirements/base.in
-pbr==5.4.4                # via stevedore
+edx-opaque-keys==2.1.0    # via -r requirements/base.in
+pbr==5.4.5                # via stevedore
 pymongo==3.10.1           # via edx-opaque-keys
 six==1.14.0               # via -r requirements/base.in, edx-opaque-keys, stevedore
 stevedore==1.32.0         # via edx-opaque-keys

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,6 +7,3 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
-
-# These packages are backports which can only be installed on Python 2.7
-futures ; python_version == "2.7"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,49 +5,43 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
-astroid==1.6.6            # via -r requirements/test.txt, pylint, pylint-celery
-backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
+astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
-click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
-configparser==4.0.2       # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, virtualenv, zipp
-coverage==5.0.4           # via -r requirements/test.txt
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
+coverage==5.1             # via -r requirements/test.txt
 ddt==1.3.1                # via -r requirements/test.txt
 distlib==0.3.0            # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
 edx-lint==1.4.1           # via -r requirements/test.txt
-edx-opaque-keys==2.0.1    # via -r requirements/test.txt
-enum34==1.1.10            # via -r requirements/test.txt, astroid
+edx-opaque-keys==2.1.0    # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/test.txt, -r requirements/travis.txt, tox, virtualenv
-funcsigs==1.0.2           # via -r requirements/test.txt, mock
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
-importlib-metadata==1.5.0  # via -r requirements/test.txt, -r requirements/travis.txt, importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
+importlib-metadata==1.6.0  # via -r requirements/test.txt, -r requirements/travis.txt, importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 nose==1.3.7               # via -r requirements/test.txt
 packaging==20.3           # via -r requirements/test.txt, -r requirements/travis.txt, tox
-pathlib2==2.3.5           # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, virtualenv
-pbr==5.4.4                # via -r requirements/test.txt, stevedore
-pip-tools==4.5.1          # via -r requirements/pip-tools.txt
+pbr==5.4.5                # via -r requirements/test.txt, stevedore
+pip-tools==5.1.2          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, -r requirements/travis.txt, tox
 py==1.8.1                 # via -r requirements/test.txt, -r requirements/travis.txt, tox
 pycodestyle==2.5.0        # via -r requirements/test.txt
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/test.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
-pyparsing==2.4.6          # via -r requirements/test.txt, -r requirements/travis.txt, packaging
-scandir==1.10.0           # via -r requirements/test.txt, -r requirements/travis.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/test.txt, -r requirements/travis.txt, astroid, importlib-resources, pylint
-six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, edx-opaque-keys, mock, packaging, pathlib2, pip-tools, pylint, singledispatch, stevedore, tox, virtualenv
+pyparsing==2.4.7          # via -r requirements/test.txt, -r requirements/travis.txt, packaging
+six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, edx-opaque-keys, mock, packaging, pip-tools, stevedore, tox, virtualenv
 stevedore==1.32.0         # via -r requirements/test.txt, edx-opaque-keys
 toml==0.10.0              # via -r requirements/test.txt, -r requirements/travis.txt, tox
 tox-battery==0.5.2        # via -r requirements/dev.in
-tox==3.14.5               # via -r requirements/test.txt, -r requirements/travis.txt, tox-battery
-typing==3.7.4.1           # via -r requirements/test.txt, -r requirements/travis.txt, importlib-resources
-virtualenv==20.0.10       # via -r requirements/test.txt, -r requirements/travis.txt, tox
-wrapt==1.12.1             # via -r requirements/test.txt, astroid
+tox==3.15.0               # via -r requirements/test.txt, -r requirements/travis.txt, tox-battery
+typed-ast==1.4.1          # via -r requirements/test.txt, astroid
+virtualenv==20.0.20       # via -r requirements/test.txt, -r requirements/travis.txt, tox
+wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,9 @@
 #
 #    make upgrade
 #
-click==7.1.1              # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip-tools.in
+click==7.1.2              # via pip-tools
+pip-tools==5.1.2          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,47 +5,38 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-astroid==1.6.6            # via pylint, pylint-celery
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
+astroid==2.3.3            # via pylint, pylint-celery
 click-log==0.3.2          # via edx-lint
-click==7.1.1              # via click-log, edx-lint
-configparser==4.0.2       # via importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
-coverage==5.0.4           # via -r requirements/test.in
+click==7.1.2              # via click-log, edx-lint
+coverage==5.1             # via -r requirements/test.in
 ddt==1.3.1                # via -r requirements/test.in
 distlib==0.3.0            # via virtualenv
 edx-lint==1.4.1           # via -r requirements/test.in
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt
-enum34==1.1.10            # via astroid
+edx-opaque-keys==2.1.0    # via -r requirements/base.txt
 filelock==3.0.12          # via tox, virtualenv
-funcsigs==1.0.2           # via mock
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
-importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.in, astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 nose==1.3.7               # via -r requirements/test.in
 packaging==20.3           # via tox
-pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
-pbr==5.4.4                # via -r requirements/base.txt, stevedore
+pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pycodestyle==2.5.0        # via -r requirements/test.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
-pyparsing==2.4.6          # via packaging
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via astroid, importlib-resources, pylint
-six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, edx-opaque-keys, mock, packaging, pathlib2, pylint, singledispatch, stevedore, tox, virtualenv
+pyparsing==2.4.7          # via packaging
+six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, edx-opaque-keys, mock, packaging, stevedore, tox, virtualenv
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/test.in
-typing==3.7.4.1           # via importlib-resources
-virtualenv==20.0.10       # via tox
-wrapt==1.12.1             # via astroid
+tox==3.15.0               # via -r requirements/test.in
+typed-ast==1.4.1          # via astroid
+virtualenv==20.0.20       # via tox
+wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,22 +5,16 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 packaging==20.3           # via tox
-pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via importlib-resources
-six==1.14.0               # via packaging, pathlib2, tox, virtualenv
+pyparsing==2.4.7          # via packaging
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/travis.in
-typing==3.7.4.1           # via importlib-resources
-virtualenv==20.0.10       # via tox
+tox==3.15.0               # via -r requirements/travis.in
+virtualenv==20.0.20       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def is_requirement(line):
 
 setup(
     name='edx-ccx-keys',
-    version='1.0.1',
+    version='1.1.0',
     author='edX',
     author_email='oscm@edx.org',
     description='Opaque key support custom courses on edX',
@@ -48,10 +48,9 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=[
         'ccx_keys',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py{35,38},quality
 
 [testenv]
 deps =
@@ -8,3 +8,8 @@ deps =
 commands =
     coverage run -m nose
     coverage report -m
+
+[testenv:quality]
+commands =
+    pycodestyle --config=.pep8 ccx_keys
+    pylint --rcfile=pylintrc ccx_keys


### PR DESCRIPTION
## Description
Add tests with python 3.8
Drop support for python 2.7
Run `make upgrade`
Move quality test to its own travis worker.
Create new release

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179