### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ ccx-keys provides implementations of the Opaque Key concept specific to Custom C
 For more on opaque keys see `the opaque-keys package`_, `its documentation`_, or
 the `edx-platform wiki documentation`_ regarding opaque keys.
 
-.. |build-status| image:: https://travis-ci.org/edx/ccx-keys.svg?branch=master
-   :target: https://travis-ci.org/edx/ccx-keys
+.. |build-status| image:: https://travis-ci.com/edx/ccx-keys.svg?branch=master
+   :target: https://travis-ci.com/edx/ccx-keys
 .. |coverage-status| image:: https://coveralls.io/repos/edx/ccx-keys/badge.svg
    :target: https://coveralls.io/r/edx/ccx-keys
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089